### PR TITLE
Update Lavaplayer library to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     //Lavaplayer
-    compile group: 'com.sedmelluq', name: 'lavaplayer', version: '1.3.50'
+    compile group: 'com.sedmelluq', name: 'lavaplayer', version: '1.3.63'
     //Nas for audio sending
     compile group: 'com.sedmelluq', name: 'jda-nas', version: '1.1.0'
     //JDA


### PR DESCRIPTION
Seems to have fixed issue #55. Error messages were related to this library and getting YouTube responses with it. Simply updating the version that Moosic is compiled with fixed the issue entirely.