### PR TITLE
5.3 fix

### DIFF
--- a/5.3fix
+++ b/5.3fix
@@ -1,0 +1,61 @@
+plugins {
+    id 'java'
+    id 'application'
+    id 'com.github.johnrengelman.shadow' version '5.2.0'
+}
+
+group 'Moosic'
+version '5.3'
+
+mainClassName = "co.moosic.music.Login"
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+repositories {
+    jcenter()
+    maven {
+	url 'https://jitpack.io' 
+  }
+	maven {
+    url 'https://m2.dv8tion.net/releases'
+  }
+}
+
+
+dependencies {
+	//Lavaplayer
+	implementation 'com.sedmelluq:lavaplayer:1.3.77'
+    //Nas for audio sending
+    implementation 'com.sedmelluq:jda-nas:1.1.0'
+    //JDA
+    implementation 'net.dv8tion:JDA:4.2.0_183'
+    //Configuration builder
+    implementation 'com.github.kaaz:configurationbuilder:0.4'
+    //Logback
+    implementation 'ch.qos.logback:logback-classic:1.2.3'
+
+}
+
+compileJava {
+    classpath = sourceSets.main.compileClasspath
+    options.encoding = 'UTF-8'
+}
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+build.dependsOn shadowJar
+
+artifacts {
+    archives shadowJar
+}
+
+jar {
+    baseName 'moosic'
+}
+
+wrapper {
+    gradleVersion = "6.5.1"
+}

--- a/5.3fix
+++ b/5.3fix
@@ -14,21 +14,26 @@ targetCompatibility = 1.8
 
 repositories {
     jcenter()
-    maven { url 'https://jitpack.io' }
+    maven {
+	url 'https://jitpack.io' 
+  }
+	maven {
+    url 'https://m2.dv8tion.net/releases'
+  }
 }
 
 
 dependencies {
-    //Lavaplayer
-    compile group: 'com.sedmelluq', name: 'lavaplayer', version: '1.3.50'
+	//Lavaplayer
+	implementation 'com.sedmelluq:lavaplayer:1.3.77'
     //Nas for audio sending
-    compile group: 'com.sedmelluq', name: 'jda-nas', version: '1.1.0'
+    implementation 'com.sedmelluq:jda-nas:1.1.0'
     //JDA
-    compile group: 'net.dv8tion', name: 'JDA', version: '4.2.0_183'
+    implementation 'net.dv8tion:JDA:4.2.0_183'
     //Configuration builder
-    compile group: 'com.github.kaaz', name: 'configurationbuilder', version: '0.4'
+    implementation 'com.github.kaaz:configurationbuilder:0.4'
     //Logback
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    implementation 'ch.qos.logback:logback-classic:1.2.3'
 
 }
 

--- a/5.3fix
+++ b/5.3fix
@@ -14,26 +14,21 @@ targetCompatibility = 1.8
 
 repositories {
     jcenter()
-    maven {
-	url 'https://jitpack.io' 
-  }
-	maven {
-    url 'https://m2.dv8tion.net/releases'
-  }
+    maven { url 'https://jitpack.io' }
 }
 
 
 dependencies {
-	//Lavaplayer
-	implementation 'com.sedmelluq:lavaplayer:1.3.77'
+    //Lavaplayer
+    compile group: 'com.sedmelluq', name: 'lavaplayer', version: '1.3.50'
     //Nas for audio sending
-    implementation 'com.sedmelluq:jda-nas:1.1.0'
+    compile group: 'com.sedmelluq', name: 'jda-nas', version: '1.1.0'
     //JDA
-    implementation 'net.dv8tion:JDA:4.2.0_183'
+    compile group: 'net.dv8tion', name: 'JDA', version: '4.2.0_183'
     //Configuration builder
-    implementation 'com.github.kaaz:configurationbuilder:0.4'
+    compile group: 'com.github.kaaz', name: 'configurationbuilder', version: '0.4'
     //Logback
-    implementation 'ch.qos.logback:logback-classic:1.2.3'
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 
 }
 


### PR DESCRIPTION
Fixed repositories and dependencies (see below). This fix worked for me on the latest version of Java, I have both 32 and 64 bit installed. It may or may not work for you but I hope it does!

[moosic.zip](https://github.com/Repulser/Moosic/files/8534861/moosic.zip)

- Added https://m2.dv8tion.net/releases to repositories, needed for latest version of lavaplayer
- "compile" has been depreciated from gradle. Changed to "implementation".
